### PR TITLE
Make it so Jenkins doesnt stop build in CB on success

### DIFF
--- a/src/main/java/io/jenkins/plugins/codebuildcloud/CodeBuildAgent.java
+++ b/src/main/java/io/jenkins/plugins/codebuildcloud/CodeBuildAgent.java
@@ -73,7 +73,14 @@ public class CodeBuildAgent extends AbstractCloudSlave {
 
       LOGGER.finest("Terminating agent Step2: " + getDisplayName());
       try {
-        cloud.getClient().stopBuild(buildId);
+        if (comp.getCompletedWithoutErrors()) {
+          // Let the rest of the build process run within codebuild
+          // Do not call stop - let codebuild nateively end.
+          // See #https://github.com/jenkinsci/codebuild-cloud-plugin/issues/21
+        } else {
+          // Stop hard the build in codebuild. Saves jenkins admin money
+          cloud.getClient().stopBuild(buildId);
+        }
       } catch (ResourceNotFoundException e) {
         // this is fine. really.
       } catch (Exception e) {

--- a/src/main/java/io/jenkins/plugins/codebuildcloud/CodeBuildClientWrapper.java
+++ b/src/main/java/io/jenkins/plugins/codebuildcloud/CodeBuildClientWrapper.java
@@ -116,6 +116,8 @@ public class CodeBuildClientWrapper {
 
   public void stopBuild(@NonNull String buildId) {
 
+    LOGGER.finest(String.format("Stop Build Requested for build ID: %s", buildId));
+
     CodeBuildStatus status = getBuildStatus(buildId);
 
     // No other use cases make sense to stop the build right?

--- a/src/main/java/io/jenkins/plugins/codebuildcloud/CodeBuildComputer.java
+++ b/src/main/java/io/jenkins/plugins/codebuildcloud/CodeBuildComputer.java
@@ -11,14 +11,21 @@ public class CodeBuildComputer extends AbstractCloudComputer<CodeBuildAgent> {
 
   private static final Logger LOGGER = Logger.getLogger(CodeBuildComputer.class.getName());
   private String buildId;
+  private boolean completedWithoutErrors;
 
   public CodeBuildComputer(CodeBuildAgent agent) {
     super(agent);
+
+    completedWithoutErrors = false;
   }
 
   // Package levl visibility
   String getBuildId() {
     return buildId;
+  }
+
+  boolean getCompletedWithoutErrors() {
+    return completedWithoutErrors;
   }
 
   // Package levl visibility
@@ -40,6 +47,8 @@ public class CodeBuildComputer extends AbstractCloudComputer<CodeBuildAgent> {
   public void taskCompleted(Executor executor, Queue.Task task, long durationMS) {
     super.taskCompleted(executor, task, durationMS);
     LOGGER.log(Level.FINE, "[{0}]: taskCompleted", this);
+    completedWithoutErrors = true;
+
   }
 
   /** {@inheritDoc} */
@@ -48,6 +57,7 @@ public class CodeBuildComputer extends AbstractCloudComputer<CodeBuildAgent> {
     super.taskCompletedWithProblems(executor, task, durationMS, problems);
     LOGGER.severe(String.format("[%s]: Task in job '%s' completed with problems in %sms", this,
         task.getFullDisplayName(), durationMS));
+    completedWithoutErrors = false;
   }
 
   /** {@inheritDoc} */


### PR DESCRIPTION
See #21 .  We should allow codebuild to natively end unless we can detect a failure in the provisioning process.  We should default to stop build, but if everything succeeds at provisioning, then allow codebuild to stop natively. 

