### PR TITLE
Fixes getURL() override accidental use

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,14 +112,14 @@ Makes Codebuild buildjobs a Jenkins Agent.
     - Requires Java 17.  We use [Coretto](https://aws.amazon.com/corretto).
     - Export JAVA_HOME, IE:
       ```
-      export JAVA_HOME=/Library/Java/JavaVirtualMachines/amazon-corretto-17.jdk/Contents/Home
+      export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
       ```
     - Make sure you have a new version of maven:
     `brew install maven`
     - `mvn verify` or `mvn clean install` to build
-    - To run a local instance `mvn clean  hpi:run`
+    - To run a local instance `mvn clean  hpi:run` or `mvn clean compile hpi:run`
   - Useful Maven calls
-    - Use for debug logging - `mvn clean hpi:run -Djava.util.logging.config.file=resources/logging.properties`
+    - Use for debug logging - `mvn clean compile hpi:run -Djava.util.logging.config.file=resources/logging.properties`
 
 ### Tips
 - When updating the `pom.xml` specifically jenkins dependencies like modules and plugins, use https://repo.jenkins-ci.org/public/org to determine correct versions.  While there might be newer versions in maven central or other repositories, it will fail in Github Actions.

--- a/src/main/java/io/jenkins/plugins/codebuildcloud/CodeBuildCloud.java
+++ b/src/main/java/io/jenkins/plugins/codebuildcloud/CodeBuildCloud.java
@@ -790,10 +790,10 @@ public class CodeBuildCloud extends Cloud {
     @POST
     public FormValidation doCheckName(@QueryParameter String value) throws IOException, ServletException {
 
-      if (value.length() > 0 &&
+      if (value != null &&
+          value.length() > 0 &&
           value.length() <= 100
-          && value.matches(CLOUD_NAME_PATTERN)
-          && value != null) {
+          && value.matches(CLOUD_NAME_PATTERN)) {
         return FormValidation.ok();
       }
       return FormValidation

--- a/src/main/java/io/jenkins/plugins/codebuildcloud/CodeBuildLauncher.java
+++ b/src/main/java/io/jenkins/plugins/codebuildcloud/CodeBuildLauncher.java
@@ -198,13 +198,13 @@ public class CodeBuildLauncher extends JNLPLauncher {
       }
     } else if (cloud.getWebSocket()) { // websocket use case
       mylist.add(createEnvVariable("JENKINS_WEB_SOCKET", "true"));
-      mylist.add(createEnvVariable("JENKINS_URL", cloud.getUrl()));
+      mylist.add(createEnvVariable("JENKINS_URL", cloud.getJenkinsUrl()));
     } else {
       if (StringUtils.isNotEmpty(cloud.getTunnel())) {
         mylist.add(createEnvVariable("JENKINS_TUNNEL", cloud.getTunnel()));
       }
 
-      mylist.add(createEnvVariable("JENKINS_URL", cloud.getUrl()));
+      mylist.add(createEnvVariable("JENKINS_URL", cloud.getJenkinsUrl()));
 
       if (StringUtils.isNotEmpty(proxyCredentials)) {
         mylist.add(createEnvVariable("JENKINS_CODEBUILD_PROXY_CREDENTIALS",
@@ -230,7 +230,7 @@ public class CodeBuildLauncher extends JNLPLauncher {
     // Extra helper environment variables for downloading the JAR file instead of
     // over the internet
     try {
-      java.net.URL myurl = new java.net.URL(cloud.getUrl());
+      java.net.URL myurl = new java.net.URL(cloud.getJenkinsUrl());
 
       mylist.add(createEnvVariable("JENKINS_CODEBUILD_AGENT_URL",
           myurl.getProtocol() + "://" + myurl.getAuthority() + "/jnlpJars/agent.jar"));

--- a/src/main/resources/io/jenkins/plugins/codebuildcloud/CodeBuildCloud/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/codebuildcloud/CodeBuildCloud/config.jelly
@@ -2,6 +2,12 @@
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
   
+  <f:entry field="name" title="${%Name}" >
+    <f:textbox />
+  </f:entry>
+
+  <f:advanced title="Show More">
+
   <f:entry  field="credentialId" title="${%AWS Credentials}">
     <c:select/>
   </f:entry>
@@ -81,14 +87,14 @@
     </f:entry>
 
 
-    <f:entry field="url" title="${%url}">
-      <f:textbox default="${descriptor.defaultUrl}" />
+    <f:entry field="jenkinsUrl" title="${%jenkinsUrl}">
+      <f:textbox default="${descriptor.defaultJenkinsUrl}" />
     </f:entry>
 
     <f:entry field="webSocket" title="${%Enable websocket}">
       <f:checkbox />
     </f:entry>
     </f:advanced>
-
+ </f:advanced>
 
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/codebuildcloud/CodeBuildCloud/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/codebuildcloud/CodeBuildCloud/config.jelly
@@ -2,9 +2,12 @@
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
   
-  <f:entry field="name" title="${%Name}" >
+
+  <f:readOnlyTextbox field="name" title="${%Name}" >
     <f:textbox />
-  </f:entry>
+  </f:readOnlyTextbox>
+  <br />
+
 
   <f:advanced title="Show More">
 

--- a/src/main/resources/io/jenkins/plugins/codebuildcloud/CodeBuildCloud/help-jenkinsUrl.html
+++ b/src/main/resources/io/jenkins/plugins/codebuildcloud/CodeBuildCloud/help-jenkinsUrl.html
@@ -1,0 +1,4 @@
+<p>
+  See <a href="https://github.com/jenkinsci/remoting/blob/master/src/main/java/hudson/remoting/jnlp/Main.java">this</a>
+  for details. Specify the Jenkins root URLs to connect to.
+</p>

--- a/src/main/resources/io/jenkins/plugins/codebuildcloud/CodeBuildCloud/help-tunnel.html
+++ b/src/main/resources/io/jenkins/plugins/codebuildcloud/CodeBuildCloud/help-tunnel.html
@@ -1,0 +1,6 @@
+<p>
+  See <a href="https://github.com/jenkinsci/remoting/blob/master/src/main/java/hudson/remoting/jnlp/Main.java">this</a>
+  for details. Connect to the specified host and port, instead of connecting directly to Jenkins. Useful when connection
+  to Jenkins needs to be tunneled. Can be also HOST: or :PORT, in which case the missing portion will be auto-configured
+  like the default behavior
+</p>

--- a/src/test/java/io/jenkins/plugins/codebuildcloud/CodeBuildCloudTest.java
+++ b/src/test/java/io/jenkins/plugins/codebuildcloud/CodeBuildCloudTest.java
@@ -12,7 +12,8 @@ public class CodeBuildCloudTest {
 
   @Test
   public void testInitPlugin() throws Exception {
-    final CodeBuildCloud cloud = new CodeBuildCloud(null, "hello", null, null, null, null, null, null, null, null, null,
+    final CodeBuildCloud cloud = new CodeBuildCloud("Test1", "hello", null, null, null, null, null, null, null, null,
+        null,
         null,
         null,
         null, null, null, null, null, null, null, null, null);


### PR DESCRIPTION
Fix #26 

### Testing done

- Worked on 2.414.2
- Worked on 2.401.1
- (Note - was failing on 2.414.2 before this change due to accidental override of `getUrl()` from base class



### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira


