### PR TITLE
Migrate from Commons Lang 2 to Commons Lang 3

### DIFF
--- a/src/main/java/io/jenkins/plugins/codebuildcloud/CodeBuildAgent.java
+++ b/src/main/java/io/jenkins/plugins/codebuildcloud/CodeBuildAgent.java
@@ -3,7 +3,7 @@ package io.jenkins.plugins.codebuildcloud;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.logging.Logger;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.amazonaws.services.codebuild.model.ResourceNotFoundException;
 

--- a/src/main/java/io/jenkins/plugins/codebuildcloud/CodeBuildCloud.java
+++ b/src/main/java/io/jenkins/plugins/codebuildcloud/CodeBuildCloud.java
@@ -14,9 +14,8 @@ import java.util.logging.Logger;
 
 import javax.servlet.ServletException;
 
-import org.apache.commons.lang.NullArgumentException;
-import org.apache.commons.lang.RandomStringUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.main.modules.instance_identity.InstanceIdentity;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;


### PR DESCRIPTION
Migrate from deprecated/EOL Commons Lang 2 to Commons Lang 3.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

## What's changed

- Renamed the `org.apache.commons.lang.*` imports to `org.apache.commons.lang3.*` and declared
  `io.jenkins.plugins:commons-lang3-api` (`RandomStringUtils` and `defaultIfBlank` have no clean JDK
  equivalent).
- Dropped an unused `NullArgumentException` import — that class does not exist in Lang 3.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.

The `ban-commons-lang-2` enforcer rule was left disabled: it needs parent POM `6.2116.v7501b_67dc517` or newer and this plugin is on `5.31`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact @timja.
